### PR TITLE
Non-blocking directive

### DIFF
--- a/lib/receptor_controller/client.rb
+++ b/lib/receptor_controller/client.rb
@@ -5,8 +5,10 @@ module ReceptorController
   class Client
     require "receptor_controller/client/configuration"
     require "receptor_controller/client/response_worker"
+    require "receptor_controller/client/directive_blocking"
+    require "receptor_controller/client/directive_non_blocking"
 
-    attr_accessor :default_headers, :identity_header, :logger
+    attr_accessor :default_headers, :identity_header, :logger, :response_worker
     attr_reader :config
 
     STATUS_DISCONNECTED = {'status' => 'disconnected'}.freeze
@@ -47,43 +49,17 @@ module ReceptorController
       STATUS_DISCONNECTED
     end
 
-    def send_directive(account_number, node_id,
-                       payload:,
-                       directive:,
-                       response_object:,
-                       response_callback: :response_received,
-                       timeout_callback: :response_timeout)
-      body = {
-        :account   => account_number,
-        :recipient => node_id,
-        :payload   => payload,
-        :directive => directive
-      }
-
-      response = Faraday.post(config.job_url, body.to_json, headers)
-      if response.success?
-        msg_id = JSON.parse(response.body)['id']
-
-        # registers message id for kafka responses
-        response_worker.register_message(msg_id,
-                                         response_object,
-                                         :response_callback => response_callback,
-                                         :timeout_callback  => timeout_callback)
-
-        msg_id
-      else
-        logger.error(receptor_log_msg("Directive #{directive} failed: HTTP #{response.status}", account_number, node_id))
-        nil
-      end
-    rescue Faraday::Error => e
-      logger.error(receptor_log_msg("Directive #{directive} failed", account_number, node_id, e))
-      nil
+    def directive(account_number, node_id,
+                  payload:,
+                  directive:,
+                  type: :non_blocking)
+      klass = type == :non_blocking ? DirectiveNonBlocking : DirectiveBlocking
+      klass.new(:name    => directive,
+                :account => account_number,
+                :node_id => node_id,
+                :payload => payload,
+                :client  => self)
     end
-
-    private
-
-    attr_writer :config
-    attr_accessor :response_worker
 
     def headers
       default_headers.merge(identity_header || {})
@@ -94,5 +70,9 @@ module ReceptorController
       message += "; #{exception.class.name}: #{exception.message}" if exception.present?
       message + " [Account number: #{account}; Receptor node: #{node_id}]"
     end
+
+    private
+
+    attr_writer :config
   end
 end

--- a/lib/receptor_controller/client/configuration.rb
+++ b/lib/receptor_controller/client/configuration.rb
@@ -1,18 +1,29 @@
 module ReceptorController
   class Client::Configuration
+    # Scheme of cloud receptor controller
     attr_reader :controller_scheme
+    # Host name of cloud receptor controller
     attr_reader :controller_host
 
+    # Path to connection status requests
     attr_accessor :connection_status_path
+    # Path to sending directive requests
     attr_accessor :job_path
 
+    # Kafka host name
     attr_accessor :queue_host
+    # Kafka topic max bytes received in one response
     attr_accessor :queue_max_bytes
+    # Kafka topic grouping (if nil, all subscribes receives all messages)
     attr_accessor :queue_persist_ref
+    # Kafka port
     attr_accessor :queue_port
+    # Kafka topic name for cloud receptor controller's responses
     attr_accessor :queue_topic
 
+    # Timeout for how long successful request waits for response
     attr_accessor :response_timeout
+    # Interval between timeout checks
     attr_accessor :response_timeout_poll_time
 
     def initialize

--- a/lib/receptor_controller/client/directive.rb
+++ b/lib/receptor_controller/client/directive.rb
@@ -1,0 +1,63 @@
+require "faraday"
+
+module ReceptorController
+  class Client::Directive
+    attr_accessor :name, :account, :node_id, :payload, :client
+
+    delegate :config, :logger, :receptor_log_msg, :response_worker, :to => :client
+
+    EOF_MESSAGE_TYPE = 'eof'.freeze
+
+    def initialize(name:, account:, node_id:, payload:, client:)
+      self.account         = account
+      self.client          = client
+      self.name            = name
+      self.node_id         = node_id
+      self.payload         = payload
+    end
+
+    def call
+      raise NotImplementedError, "#{__method__} must be implemented in a subclass"
+    end
+
+    def on_success(&block)
+      @on_response ||= []
+      @on_response << block if block_given?
+      @on_response
+    end
+
+    def on_eof(&block)
+      @on_eof ||= []
+      @on_eof << block if block_given?
+      @on_eof
+    end
+
+    def on_timeout(&block)
+      @on_timeout ||= []
+      @on_timeout << block if block_given?
+      @on_timeout
+    end
+
+    def on_error(&block)
+      @on_error ||= []
+      @on_error << block if block_given?
+      @on_error
+    end
+
+    def response_success(msg_id, message_type, response)
+      if message_type == EOF_MESSAGE_TYPE
+        on_eof.each { |block| block.call(msg_id) }
+      else
+        on_success.each { |block| block.call(msg_id, response) }
+      end
+    end
+
+    def response_error(msg_id, response_code)
+      on_error.each { |block| block.call(msg_id, response_code) }
+    end
+
+    def response_timeout(msg_id)
+      on_timeout.each { |block| block.call(msg_id) }
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -2,7 +2,7 @@ require "receptor_controller/client/directive"
 
 module ReceptorController
   class Client::DirectiveBlocking < Client::Directive
-    def call
+    def call(_body = default_body)
 
     end
   end

--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -1,0 +1,9 @@
+require "receptor_controller/client/directive"
+
+module ReceptorController
+  class Client::DirectiveBlocking < Client::Directive
+    def call
+
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -1,0 +1,30 @@
+require "receptor_controller/client/directive"
+
+module ReceptorController
+  class Client::DirectiveNonBlocking < Client::Directive
+    def call
+      body = {
+        :account   => account,
+        :recipient => node_id,
+        :payload   => payload,
+        :directive => name
+      }
+
+      response = Faraday.post(config.job_url, body.to_json, client.headers)
+      if response.success?
+        msg_id = JSON.parse(response.body)['id']
+
+        # registers message id for kafka responses
+        response_worker.register_message(msg_id, self)
+
+        msg_id
+      else
+        logger.error(receptor_log_msg("Directive #{name} failed: HTTP #{response.status}", account, node_id))
+        nil
+      end
+    rescue Faraday::Error => e
+      logger.error(receptor_log_msg("Directive #{name} failed", account, node_id, e))
+      nil
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -2,14 +2,7 @@ require "receptor_controller/client/directive"
 
 module ReceptorController
   class Client::DirectiveNonBlocking < Client::Directive
-    def call
-      body = {
-        :account   => account,
-        :recipient => node_id,
-        :payload   => payload,
-        :directive => name
-      }
-
+    def call(body = default_body)
       response = Faraday.post(config.job_url, body.to_json, client.headers)
       if response.success?
         msg_id = JSON.parse(response.body)['id']
@@ -25,6 +18,46 @@ module ReceptorController
     rescue Faraday::Error => e
       logger.error(receptor_log_msg("Directive #{name} failed", account, node_id, e))
       nil
+    end
+
+    def on_success(&block)
+      @on_response ||= []
+      @on_response << block if block_given?
+      @on_response
+    end
+
+    def on_eof(&block)
+      @on_eof ||= []
+      @on_eof << block if block_given?
+      @on_eof
+    end
+
+    def on_timeout(&block)
+      @on_timeout ||= []
+      @on_timeout << block if block_given?
+      @on_timeout
+    end
+
+    def on_error(&block)
+      @on_error ||= []
+      @on_error << block if block_given?
+      @on_error
+    end
+
+    def response_success(msg_id, message_type, response)
+      if message_type == MESSAGE_TYPE_EOF
+        on_eof.each { |block| block.call(msg_id) }
+      else
+        on_success.each { |block| block.call(msg_id, response) }
+      end
+    end
+
+    def response_error(msg_id, response_code)
+      on_error.each { |block| block.call(msg_id, response_code) }
+    end
+
+    def response_timeout(msg_id)
+      on_timeout.each { |block| block.call(msg_id) }
     end
   end
 end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -57,8 +57,9 @@ module ReceptorController
       end
     end
 
-    def response_error(msg_id, response_code)
-      @error_callbacks.each { |block| block.call(msg_id, response_code) }
+    # TODO: update args in satellite's availability check!
+    def response_error(msg_id, response_code, response)
+      @error_callbacks.each { |block| block.call(msg_id, response_code, response) }
     end
 
     def response_timeout(msg_id)

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -1,6 +1,30 @@
 require "receptor_controller/client/directive"
 
 module ReceptorController
+  # Non-blocking directive for requests through POST /job
+  # Directive's call returns either message ID or nil
+  #
+  # Callback blocks can be specified for handling responses
+  # @example:
+  #         receiver = <object with methods below>
+  #         directive
+  #           .on_success do |msg_id, response|
+  #             receiver.process_response(msg_id, response)
+  #           end
+  #           .on_error do |msg_id, code, response|
+  #             receiver.process_error(msg_id, code, response)
+  #           end
+  #           .on_timeout do |msg_id|
+  #             receiver.process_timeout(msg_id)
+  #           end
+  #           .on_eof do |msg_id|
+  #             receiver.process_eof(msg_id)
+  #           end
+  #           .on_eof do |msg_id|
+  #             logger.debug("[#{msg_id}] EOF message received")
+  #           end
+  #
+  #         directive.call
   class Client::DirectiveNonBlocking < Client::Directive
     def initialize(name:, account:, node_id:, payload:, client:)
       super

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -25,6 +25,9 @@ module ReceptorController
         nil
       end
     rescue Faraday::Error => e
+      logger.error(receptor_log_msg("Directive #{name} failed. POST /job error", account, node_id, e))
+      nil
+    rescue => e
       logger.error(receptor_log_msg("Directive #{name} failed", account, node_id, e))
       nil
     end
@@ -57,7 +60,6 @@ module ReceptorController
       end
     end
 
-    # TODO: update args in satellite's availability check!
     def response_error(msg_id, response_code, response)
       @error_callbacks.each { |block| block.call(msg_id, response_code, response) }
     end

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -43,9 +43,13 @@ module ReceptorController
     # @param receiver [Object] any object implementing callbacks
     # @param response_callback [Symbol] name of receiver's method processing responses
     # @param timeout_callback [Symbol] name of receiver's method processing timeout [optional]
-    def register_message(msg_id, receiver, response_callback: :response_received, timeout_callback: :response_timeout)
+    def register_message(msg_id, receiver, response_callback: :response_success, timeout_callback: :response_timeout, error_callback: :response_error)
       logger.debug("Receptor response: registering message #{msg_id}")
-      registered_messages[msg_id] = {:receiver => receiver, :response_callback => response_callback, :timeout_callback => timeout_callback, :registered_at => Time.now.utc}
+      registered_messages[msg_id] = {:receiver          => receiver,
+                                     :response_callback => response_callback,
+                                     :timeout_callback  => timeout_callback,
+                                     :error_callback    => error_callback,
+                                     :registered_at     => Time.now.utc}
     end
 
     private
@@ -69,29 +73,34 @@ module ReceptorController
 
     def process_message(message)
       response = JSON.parse(message.payload)
-      if response['code'] == 0
-        message_id = response['in_response_to']
-        # message_type: "response" (with data) or
-        #               "eof"(without data)
-        message_type = response['message_type']
 
-        if message_id
-          if (callbacks = registered_messages[message_id]).present?
-            logger.debug("Receptor response: processing message #{message_id} (#{response})")
+      if (message_id = response['in_response_to'])
+        if (callbacks = registered_messages[message_id]).present?
+          logger.debug("Receptor response: processing message #{message_id} (#{response})")
+          if response['code'] == 0
+            #
+            # Response OK
+            #
+            message_type = response['message_type'] # "response" (with data) or "eof" (without data)
             registered_messages.delete(message_id) if message_type == 'eof'
-            # Callback to sender
             callbacks[:receiver].send(callbacks[:response_callback], message_id, message_type, response['payload'])
+          else
+            #
+            # Response Error
+            #
+            registered_messages.delete(message_id)
+            callbacks[:receiver].send(callbacks[:error_callback], message_id, response['code'])
           end
         else
-          raise "Message id (in_response_to) not received! #{response}"
+          # noop, it's not error if not registered, can be processed by another pod
         end
       else
-        logger.error("Receptor_satellite:health_check directive failed in receptor_client node #{response['sender']}")
+        logger.error("Receptor response: Message id (in_response_to) not received! #{response}")
       end
     rescue JSON::ParserError => e
-      logger.error("Failed to parse Kafka response (#{e.message})\n#{message.payload}")
+      logger.error("Receptor response: Failed to parse Kafka response (#{e.message})\n#{message.payload}")
     rescue => e
-      logger.error("#{e}\n#{e.backtrace.join("\n")}")
+      logger.error("Receptor response: #{e}\n#{e.backtrace.join("\n")}")
     end
 
     def check_timeouts(threshold = config.response_timeout)
@@ -135,7 +144,7 @@ module ReceptorController
         :host       => config.queue_host,
         :port       => config.queue_port,
         :protocol   => :Kafka,
-        :client_ref => "tp-inventory-receptor_client-responses-#{Time.now.to_i}", # A reference string to identify the client
+        :client_ref => "receptor_client-responses-#{Time.now.to_i}", # A reference string to identify the client
       }
     end
   end

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -1,6 +1,19 @@
 require "concurrent"
 
 module ReceptorController
+  # ResponseWorker is listening on Kafka topic platform.receptor-controller.responses (@see Configuration.queue_topic)
+  # It asynchronously receives responses requested by POST /job to receptor controller.
+  # Request and response is paired by message ID (response of POST /job and 'in_response_to' value in kafka response here)
+  #
+  # Successful responses are at least two:
+  # * 1+ of 'response' type, containing data
+  # * 1 of 'eof' type, signalizing end of transmission
+  #
+  # Registered messages without response are removed after timeout (Configuration.response_timeout)
+  #
+  # All type of responses/timeout can be sent to registered callbacks (@see :register_message)
+  #
+  # Use "start" and "stop" methods to start/stop listening on Kafka
   class Client::ResponseWorker
     attr_reader :started
     alias_method :started?, :started

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -44,6 +44,7 @@ module ReceptorController
     # @param response_callback [Symbol] name of receiver's method processing responses
     # @param timeout_callback [Symbol] name of receiver's method processing timeout [optional]
     def register_message(msg_id, receiver, response_callback: :response_received, timeout_callback: :response_timeout)
+      logger.debug("Receptor response: registering message #{msg_id}")
       registered_messages[msg_id] = {:receiver => receiver, :response_callback => response_callback, :timeout_callback => timeout_callback, :registered_at => Time.now.utc}
     end
 
@@ -76,6 +77,7 @@ module ReceptorController
 
         if message_id
           if (callbacks = registered_messages[message_id]).present?
+            logger.debug("Receptor response: processing message #{message_id} (#{response})")
             registered_messages.delete(message_id) if message_type == 'eof'
             # Callback to sender
             callbacks[:receiver].send(callbacks[:response_callback], message_id, message_type, response['payload'])

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -89,7 +89,7 @@ module ReceptorController
             # Response Error
             #
             registered_messages.delete(message_id)
-            callbacks[:receiver].send(callbacks[:error_callback], message_id, response['code'])
+            callbacks[:receiver].send(callbacks[:error_callback], message_id, response['code'], response['payload'])
           end
         else
           # noop, it's not error if not registered, can be processed by another pod

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -21,14 +21,13 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '~> 5.2.2'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
-  s.add_runtime_dependency 'faraday', '~> 1.0'
+  s.add_runtime_dependency 'faraday'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
   s.add_runtime_dependency 'manageiq-loggers', '~> 0.4.0', '>= 0.4.2'
   s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'
 
-  s.add_development_dependency 'bundler', '~> 2.0'
-  s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
-  s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/spec/receptor_controller/client_spec.rb
+++ b/spec/receptor_controller/client_spec.rb
@@ -1,8 +1,8 @@
 require "receptor_controller/client"
 
 RSpec.describe ReceptorController::Client do
-  let(:external_tenant) {'0000001'}
-  let(:organization_id) {'000001'}
+  let(:external_tenant) { '0000001' }
+  let(:organization_id) { '000001' }
   let(:identity) do
     {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => external_tenant, "user" => {"is_org_admin" => true}, "internal" => {"org_id" => organization_id}}}.to_json)}
   end
@@ -21,9 +21,9 @@ RSpec.describe ReceptorController::Client do
       config.controller_host   = receptor_host
     end
   end
-  let(:satellite_uid) {'1234567890'}
+  let(:satellite_uid) { '1234567890' }
 
-  subject {described_class.new(:config => receptor_config)}
+  subject { described_class.new(:config => receptor_config) }
 
   before do
     subject.identity_header = identity
@@ -56,59 +56,20 @@ RSpec.describe ReceptorController::Client do
     end
   end
 
+  describe "#directive" do
+    it "creates blocking or non-blocking directive" do
+      %i[blocking non_blocking].each do |type|
+        directive = subject.directive(nil,
+                                      nil,
+                                      :payload   => nil,
+                                      :directive => 'xxx',
+                                      :type      => type)
+        klass     = type == :blocking ? ReceptorController::Client::DirectiveBlocking : ReceptorController::Client::DirectiveNonBlocking
+        expect(directive).to be_a_kind_of(klass)
+      end
+    end
+  end
+
   describe "#send_directive" do
-    let(:caller) {double("Caller object")}
-    let(:payload) {{'satellite_instance_id' => satellite_uid.to_s}.to_json}
-    let(:directive) {'receptor_satellite:health_check'}
-
-    it "makes POST /job request to receptor, registers received message ID and returns it" do
-      response  = {"id" => '1234'}
-
-      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
-        .with(:body    => {:account   => external_tenant,
-                           :recipient => receptor_node,
-                           :payload   => payload,
-                           :directive => directive}.to_json,
-              :headers => headers)
-        .to_return(:status => 200, :body => response.to_json, :headers => {})
-
-      expect(subject.send(:response_worker))
-        .to receive(:register_message)
-              .with(response['id'], caller, :response_callback => :response_received, :timeout_callback => :response_timeout)
-
-      expect(subject.send_directive(external_tenant, receptor_node,
-                                    :payload         => payload,
-                                    :directive       => directive,
-                                    :response_object => caller)).to eq(response['id'])
-    end
-
-    it "makes POST /job request to receptor, doesn't register message and returns nil in case of error" do
-      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
-        .with(:body    => {:account   => external_tenant,
-                           :recipient => receptor_node,
-                           :payload   => payload,
-                           :directive => directive}.to_json,
-              :headers => headers)
-        .to_return(:status => 401, :body => {"errors" => [{"status" => 401, "detail" => "Unauthorized"}]}.to_json, :headers => {})
-
-      expect(subject.send(:response_worker)).not_to receive(:register_message)
-
-      expect(subject.send_directive(external_tenant, receptor_node,
-                                    :payload         => payload,
-                                    :directive       => directive,
-                                    :response_object => caller)).to be_nil
-
-    end
-
-    it "makes a POST request and returns disconnected if receptor unavailable" do
-      allow(Faraday).to receive(:post).and_raise(Faraday::ConnectionFailed, "Failed to open TCP connection to #{receptor_host}")
-
-      expect(subject.send(:response_worker)).not_to receive(:register_message)
-
-      expect(subject.send_directive(external_tenant, receptor_node,
-                                    :payload         => payload,
-                                    :directive       => directive,
-                                    :response_object => caller)).to be_nil
-    end
   end
 end

--- a/spec/receptor_controller/client_spec.rb
+++ b/spec/receptor_controller/client_spec.rb
@@ -69,7 +69,4 @@ RSpec.describe ReceptorController::Client do
       end
     end
   end
-
-  describe "#send_directive" do
-  end
 end

--- a/spec/receptor_controller/directive_non_blocking_spec.rb
+++ b/spec/receptor_controller/directive_non_blocking_spec.rb
@@ -1,0 +1,106 @@
+require "receptor_controller/client/directive_non_blocking"
+require "pry-byebug"
+RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
+  let(:external_tenant) { '0000001' }
+  let(:organization_id) { '000001' }
+  let(:identity) do
+    {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => external_tenant, "user" => {"is_org_admin" => true}, "internal" => {"org_id" => organization_id}}}.to_json)}
+  end
+  let(:headers) do
+    {"Content-Type"    => "application/json",
+     "User-Agent"      => "Faraday v1.0.0",
+     "Accept"          => "*/*",
+     "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
+  end
+  let(:receptor_scheme) { 'http' }
+  let(:receptor_host) { 'localhost:9090' }
+  let(:receptor_node) { 'testing-receptor' }
+  let(:receptor_config) do
+    ReceptorController::Client::Configuration.new do |config|
+      config.controller_scheme = receptor_scheme
+      config.controller_host   = receptor_host
+    end
+  end
+  let(:receptor_client) do
+    client = ReceptorController::Client.new
+    client.identity_header = identity
+    client
+  end
+
+
+  let(:satellite_uid) { '1234567890' }
+  let(:payload) { {'satellite_instance_id' => satellite_uid.to_s}.to_json }
+  let(:directive) { 'receptor_satellite:health_check' }
+
+  subject { described_class.new(:name => directive, :account => external_tenant, :node_id => receptor_node, :payload => payload, :client => receptor_client) }
+
+  describe "#call" do
+    it "makes POST /job request to receptor, registers received message ID and returns it" do
+      response = {"id" => '1234'}
+
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 200, :body => response.to_json, :headers => {})
+
+      expect(subject.response_worker).to receive(:register_message).with(response['id'], subject)
+
+      expect(subject.call).to eq(response['id'])
+    end
+
+    it "makes POST /job request to receptor, doesn't register message and returns nil in case of error" do
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 401, :body => {"errors" => [{"status" => 401, "detail" => "Unauthorized"}]}.to_json, :headers => {})
+
+      expect(subject.response_worker).not_to receive(:register_message)
+
+      expect(subject.call).to be_nil
+    end
+
+    it "makes a POST request and returns disconnected if receptor unavailable" do
+      allow(Faraday).to receive(:post).and_raise(Faraday::ConnectionFailed, "Failed to open TCP connection to #{receptor_host}")
+
+      expect(subject.response_worker).not_to receive(:register_message)
+
+      expect(subject.call).to be_nil
+    end
+  end
+
+  context "callbacks" do
+    it "calls success blocks" do
+      response_id = '1234'
+
+      # Callbacks
+      result = {}
+      subject
+        .on_success do |msg_id, payload|
+          result[:first] = {:id => msg_id, :payload => payload}
+        end
+        .on_success do |msg_id, payload|
+          result[:second] = {:id => msg_id, :payload => payload}
+        end
+
+      # HTTP request
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 200, :body => {'id' => response_id}.to_json, :headers => {})
+
+      subject.call
+
+      # Kafka response
+      expect(subject).to receive(:response_success).and_call_original
+      message_type, payload = 'response', 'Testing payload'
+      response_payload = {'code' => 0, 'in_response_to' => response_id, 'message_type' => message_type, 'payload' => payload}
+      response = double
+      allow(response).to receive(:payload).and_return(response_payload.to_json)
+      subject.response_worker.send(:process_message, response)
+
+      # Result containing both "on_success" blocks
+      block_result = {:id => response_id, :payload => payload}
+      expect(result).to eq(:first => block_result, :second => block_result)
+    end
+  end
+end

--- a/spec/receptor_controller/response_worker_spec.rb
+++ b/spec/receptor_controller/response_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReceptorController::Client::ResponseWorker do
   subject { described_class.new(config, logger) }
 
   before do
-    allow(logger).to receive(:error)
+    allow(logger).to receive_messages(%i[debug info warn error fatal])
     allow(config).to receive_messages(:response_timeout => 0, :response_timeout_poll_time => 0)
   end
 
@@ -51,7 +51,7 @@ RSpec.describe ReceptorController::Client::ResponseWorker do
       let(:payload) { {'code' => 1, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
 
       it "and calls response_error" do
-        expect(receiver).to receive(:error).with(message_id, payload['code'])
+        expect(receiver).to receive(:error).with(message_id, payload['code'], payload['payload'])
 
         subject.send(:process_message, message)
       end

--- a/spec/receptor_controller/response_worker_spec.rb
+++ b/spec/receptor_controller/response_worker_spec.rb
@@ -1,0 +1,117 @@
+require "receptor_controller/client/response_worker"
+
+RSpec.describe ReceptorController::Client::ResponseWorker do
+  let(:receiver) { double('receiver') }
+  let(:logger) { double('logger') }
+  let(:config) { double('config') }
+
+  subject { described_class.new(config, logger) }
+
+  before do
+    allow(logger).to receive(:error)
+    allow(config).to receive_messages(:response_timeout => 0, :response_timeout_poll_time => 0)
+  end
+
+  describe "#register_message" do
+    it "saves callback with message id" do
+      msg_id = '1'
+
+      subject.register_message(msg_id, receiver)
+
+      expect(subject.send(:registered_messages)[msg_id]).to match(hash_including(:receiver => receiver))
+    end
+  end
+
+  describe "#process_message" do
+    let(:message) { double('message') }
+    let(:message_id) { '1234' }
+    let(:response_body) { 'Test response' }
+    let(:payload) { {} }
+    let(:receiver) { double('receiver') }
+
+    before do
+      allow(message).to receive(:payload).and_return(payload.to_json)
+      allow(receiver).to receive_messages(:success => nil, :timeout => nil, :error => nil)
+
+      subject.register_message(message_id, receiver, :response_callback => :success, :timeout_callback => :timeout, :error_callback => :error)
+    end
+
+    context "receives successful response" do
+      let(:payload) { {'code' => 0, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
+
+      it "and calls response_callback " do
+        expect(receiver).to receive(:success).with(message_id, payload['message_type'], payload['payload'])
+
+        subject.send(:process_message, message)
+      end
+
+    end
+
+    context "receives error response" do
+      let(:payload) { {'code' => 1, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
+
+      it "and calls response_error" do
+        expect(receiver).to receive(:error).with(message_id, payload['code'])
+
+        subject.send(:process_message, message)
+      end
+    end
+
+    context "receives invalid message" do
+      let(:payload) { 'Wrong message' }
+      before do
+        allow(message).to receive(:payload).and_return(payload)
+      end
+
+      it "logs error" do
+        expect(logger).to receive(:error).with(/Receptor response: Failed to parse Kafka response/)
+
+        subject.send(:process_message, message)
+      end
+    end
+
+    context "receives response without ID" do
+      let(:payload) { {'code' => 0, 'message_type' => 'response', 'payload' => response_body} }
+
+      it "logs error" do
+        expect(logger).to receive(:error).with(/Receptor response: Message id \(in_response_to\) not received!/)
+
+        subject.send(:process_message, message)
+      end
+    end
+
+    context "receives unregistered response" do
+      let(:payload) { {'code' => 0, 'in_response_to' => '9876', 'message_type' => 'response', 'payload' => response_body} }
+
+      it "does nothing" do
+        expect(logger).not_to receive(:error)
+        %i[success error timeout].each do |callback|
+          expect(receiver).not_to receive(callback)
+        end
+
+        subject.send(:process_message, message)
+      end
+    end
+  end
+
+  describe "#check_timeouts" do
+    let(:message_id) { '1234' }
+    let(:receiver) { double('receiver') }
+
+    before do
+      allow(receiver).to receive(:timeout) do
+        subject.send(:started).value = false
+      end
+
+      subject.register_message(message_id, receiver, :response_callback => :success, :timeout_callback => :timeout, :error_callback => :error)
+    end
+
+    it "calls timeout callback if message found" do
+      subject.send(:started).value = true
+
+      expect(receiver).to receive(:timeout)
+
+      subject.send(:check_timeouts)
+    end
+  end
+end


### PR DESCRIPTION
**Issue**: #2 

Directives can be blocking and non-blocking.

This PR implements Non-blocking directive.

It uses callbacks to define behaviour of responses from kafka. 

Can be specified this way:
```
        directive = receptor_client.directive(account_number,
                                              receptor_node_id,
                                              :directive => "receptor_satellite:health_check",
                                              :payload   => {'satellite_instance_id' => source_uid.to_s}.to_json,
                                              :type      => :non_blocking)

        directive
          .on_success do |msg_id, response|
            receiver.availability_check_response(msg_id, response)
          end
          .on_error do |msg_id, code, response|
            receiver.availability_check_error(msg_id, code, response)
          end
          .on_timeout do |msg_id|
            receiver.availability_check_timeout(msg_id)
          end
          .on_eof do |msg_id|
            puts "EOF received: #{msg_id}"
          end

        directive.call
```

Directive doesn't raise exceptions

---

Based on #6 