### PR TITLE
Processing of Directives

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,7 @@
 AllCops:
   Exclude:
   - db/schema.rb
+
+# This rule makes code less readable
+Style/MultilineBlockChain:
+  Enabled: false

--- a/lib/receptor_controller/client.rb
+++ b/lib/receptor_controller/client.rb
@@ -4,9 +4,12 @@ require "manageiq-messaging"
 module ReceptorController
   class Client
     require "receptor_controller/client/configuration"
+    require "receptor_controller/client/exception"
     require "receptor_controller/client/response_worker"
+    require "receptor_controller/client/directive_blocking"
+    require "receptor_controller/client/directive_non_blocking"
 
-    attr_accessor :default_headers, :identity_header, :logger
+    attr_accessor :default_headers, :identity_header, :logger, :response_worker
     attr_reader :config
 
     STATUS_DISCONNECTED = {'status' => 'disconnected'}.freeze
@@ -47,43 +50,19 @@ module ReceptorController
       STATUS_DISCONNECTED
     end
 
-    def send_directive(account_number, node_id,
-                       payload:,
-                       directive:,
-                       response_object:,
-                       response_callback: :response_received,
-                       timeout_callback: :response_timeout)
-      body = {
-        :account   => account_number,
-        :recipient => node_id,
-        :payload   => payload,
-        :directive => directive
-      }
-
-      response = Faraday.post(config.job_url, body.to_json, headers)
-      if response.success?
-        msg_id = JSON.parse(response.body)['id']
-
-        # registers message id for kafka responses
-        response_worker.register_message(msg_id,
-                                         response_object,
-                                         :response_callback => response_callback,
-                                         :timeout_callback  => timeout_callback)
-
-        msg_id
-      else
-        logger.error(receptor_log_msg("Directive #{directive} failed: HTTP #{response.status}", account_number, node_id))
-        nil
-      end
-    rescue Faraday::Error => e
-      logger.error(receptor_log_msg("Directive #{directive} failed", account_number, node_id, e))
-      nil
+    def directive(account_number, node_id,
+                  payload:,
+                  directive:,
+                  log_message_common: nil,
+                  type: :non_blocking)
+      klass = type == :non_blocking ? DirectiveNonBlocking : DirectiveBlocking
+      klass.new(:name    => directive,
+                :account => account_number,
+                :node_id => node_id,
+                :payload => payload,
+                :log_message_common => log_message_common,
+                :client  => self)
     end
-
-    private
-
-    attr_writer :config
-    attr_accessor :response_worker
 
     def headers
       default_headers.merge(identity_header || {})
@@ -94,5 +73,9 @@ module ReceptorController
       message += "; #{exception.class.name}: #{exception.message}" if exception.present?
       message + " [Account number: #{account}; Receptor node: #{node_id}]"
     end
+
+    private
+
+    attr_writer :config
   end
 end

--- a/lib/receptor_controller/client.rb
+++ b/lib/receptor_controller/client.rb
@@ -56,12 +56,12 @@ module ReceptorController
                   log_message_common: nil,
                   type: :non_blocking)
       klass = type == :non_blocking ? DirectiveNonBlocking : DirectiveBlocking
-      klass.new(:name    => directive,
-                :account => account_number,
-                :node_id => node_id,
-                :payload => payload,
+      klass.new(:name               => directive,
+                :account            => account_number,
+                :node_id            => node_id,
+                :payload            => payload,
                 :log_message_common => log_message_common,
-                :client  => self)
+                :client             => self)
     end
 
     def headers

--- a/lib/receptor_controller/client/configuration.rb
+++ b/lib/receptor_controller/client/configuration.rb
@@ -1,18 +1,31 @@
 module ReceptorController
   class Client::Configuration
+    # Scheme of cloud receptor controller
     attr_reader :controller_scheme
+    # Host name of cloud receptor controller
     attr_reader :controller_host
 
+    # Path to connection status requests
     attr_accessor :connection_status_path
+    # Path to sending directive requests
     attr_accessor :job_path
 
+    # Kafka message auto-ack (default false)
+    attr_accessor :queue_auto_ack
+    # Kafka host name
     attr_accessor :queue_host
+    # Kafka topic max bytes received in one response
     attr_accessor :queue_max_bytes
+    # Kafka topic grouping (if nil, all subscribes receives all messages)
     attr_accessor :queue_persist_ref
+    # Kafka port
     attr_accessor :queue_port
+    # Kafka topic name for cloud receptor controller's responses
     attr_accessor :queue_topic
 
+    # Timeout for how long successful request waits for response
     attr_accessor :response_timeout
+    # Interval between timeout checks
     attr_accessor :response_timeout_poll_time
 
     def initialize
@@ -22,6 +35,7 @@ module ReceptorController
       @connection_status_path = '/connection/status'
       @job_path               = '/job'
 
+      @queue_auto_ack    = false
       @queue_host        = nil
       @queue_max_bytes   = nil
       @queue_persist_ref = nil
@@ -29,7 +43,7 @@ module ReceptorController
       @queue_topic       = 'platform.receptor-controller.responses'
 
       @response_timeout           = 2.minutes
-      @response_timeout_poll_time = 10.seconds
+      @response_timeout_poll_time = 10.seconds # TODO: use Concurrent::TimerTask
 
       yield(self) if block_given?
     end

--- a/lib/receptor_controller/client/directive.rb
+++ b/lib/receptor_controller/client/directive.rb
@@ -1,0 +1,33 @@
+require "faraday"
+
+module ReceptorController
+  class Client::Directive
+    attr_accessor :name, :account, :log_message_common, :node_id, :payload, :client
+
+    delegate :config, :logger, :receptor_log_msg, :response_worker, :to => :client
+
+    MESSAGE_TYPE_RESPONSE, MESSAGE_TYPE_EOF = 'response'.freeze, 'eof'.freeze
+
+    def initialize(name:, account:, node_id:, payload:, client:, log_message_common: nil)
+      self.account            = account
+      self.client             = client
+      self.log_message_common = log_message_common
+      self.name               = name
+      self.node_id            = node_id
+      self.payload            = payload
+    end
+
+    def call(_body = default_body)
+      raise NotImplementedError, "#{__method__} must be implemented in a subclass"
+    end
+
+    def default_body
+      {
+        :account   => account,
+        :recipient => node_id,
+        :payload   => payload,
+        :directive => name
+      }
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -1,0 +1,86 @@
+require "receptor_controller/client/directive"
+
+module ReceptorController
+  # Blocking directive for requests through POST /job
+  # Successful POST causes locking current thread until response from Kafka comes
+  #
+  # Raises kind of ReceptorController::Client::Error in case of problems/timeout
+  class Client::DirectiveBlocking < Client::Directive
+    def initialize(name:, account:, node_id:, payload:, client:, log_message_common: nil)
+      super
+      self.response_lock = Mutex.new
+      self.response_waiting = ConditionVariable.new
+      self.response_data = nil
+      self.response_exception = nil
+    end
+
+    def call(body = default_body)
+      @url = JSON.parse(body[:payload])['url']
+      response = connection.post(config.job_path, body.to_json)
+
+      msg_id = JSON.parse(response.body)['id']
+
+      # registers message id for kafka responses
+      response_worker.register_message(msg_id, self)
+      wait_for_response(msg_id)
+    rescue Faraday::Error => e
+      msg = receptor_log_msg("Directive #{name} failed (#{log_message_common}) [MSG: #{msg_id}]", account, node_id, e)
+      raise ReceptorController::Client::ControllerResponseError.new(msg)
+    end
+
+    def wait_for_response(_msg_id)
+      response_lock.synchronize do
+        response_waiting.wait(response_lock)
+
+        raise response_exception if response_failed?
+
+        response_data.dup
+      end
+    end
+
+    # TODO: Review when future plugins with more "response" messages come
+    def response_success(msg_id, message_type, response)
+      response_lock.synchronize do
+        if message_type == MESSAGE_TYPE_RESPONSE
+          self.response_data = response
+        elsif message_type == MESSAGE_TYPE_EOF
+          response_waiting.signal
+        else
+          self.response_exception = ReceptorController::Client::UnknownResponseTypeError.new("#{log_message_common}[MSG: #{msg_id}]")
+          response_waiting.signal
+        end
+      end
+    end
+
+    def response_error(msg_id, response_code, err_message)
+      response_lock.synchronize do
+        self.response_data = nil
+        self.response_exception = ReceptorController::Client::ResponseError.new("#{err_message} (code: #{response_code}) (#{log_message_common}) [MSG: #{msg_id}]")
+        response_waiting.signal
+      end
+    end
+
+    def response_timeout(msg_id)
+      response_lock.synchronize do
+        self.response_data = nil
+        self.response_exception = ReceptorController::Client::ResponseTimeoutError.new("Timeout (#{log_message_common}) [MSG: #{msg_id}]")
+        response_waiting.signal
+      end
+    end
+
+    private
+
+    attr_accessor :response_data, :response_exception, :response_lock, :response_waiting
+
+    def connection
+      @connection ||= Faraday.new(config.controller_url, :headers => client.headers) do |c|
+        c.use(Faraday::Response::RaiseError)
+        c.adapter(Faraday.default_adapter)
+      end
+    end
+
+    def response_failed?
+      response_exception.present?
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -1,0 +1,144 @@
+require "concurrent"
+require "receptor_controller/client/directive"
+
+module ReceptorController
+  # Non-blocking directive for requests through POST /job
+  # Directive's call returns either message ID or nil
+  #
+  # Callback blocks can be specified for handling responses
+  # @example:
+  #         receiver = <object with methods below>
+  #         directive
+  #           .on_success do |msg_id, response|
+  #             receiver.process_response(msg_id, response)
+  #           end
+  #           .on_error do |msg_id, code, response|
+  #             receiver.process_error(msg_id, code, response)
+  #           end
+  #           .on_timeout do |msg_id|
+  #             receiver.process_timeout(msg_id)
+  #           end
+  #           .on_eof do |msg_id|
+  #             receiver.process_eof(msg_id)
+  #           end
+  #           .on_eof do |msg_id|
+  #             logger.debug("[#{msg_id}] EOF message received")
+  #           end
+  #
+  #         directive.call
+  class Client::DirectiveNonBlocking < Client::Directive
+    def initialize(name:, account:, node_id:, payload:, client:, log_message_common: nil)
+      super
+
+      @success_callbacks = []
+      @eof_callbacks     = []
+      @timeout_callbacks = []
+      @error_callbacks   = []
+
+      @responses_count = Concurrent::AtomicFixnum.new
+      @eof_lock        = Mutex.new
+      @eof_wait        = ConditionVariable.new
+    end
+
+    # Entrypoint for request
+    def call(body = default_body)
+      response = Faraday.post(config.job_url, body.to_json, client.headers)
+      if response.success?
+        msg_id = JSON.parse(response.body)['id']
+
+        # registers message id for kafka responses
+        response_worker.register_message(msg_id, self)
+
+        msg_id
+      else
+        logger.error(receptor_log_msg("Directive #{name} failed: HTTP #{response.status}", account, node_id))
+        nil
+      end
+    rescue Faraday::Error => e
+      logger.error(receptor_log_msg("Directive #{name} failed. POST /job error", account, node_id, e))
+      nil
+    rescue => e
+      logger.error(receptor_log_msg("Directive #{name} failed", account, node_id, e))
+      nil
+    end
+
+    def on_success(&block)
+      @success_callbacks << block if block_given?
+      self
+    end
+
+    def on_eof(&block)
+      @eof_callbacks << block if block_given?
+      self
+    end
+
+    def on_timeout(&block)
+      @timeout_callbacks << block if block_given?
+      self
+    end
+
+    def on_error(&block)
+      @error_callbacks << block if block_given?
+      self
+    end
+
+    # Handles successful responses in Threads
+    # EOF processing waits until all response threads are finished
+    def response_success(msg_id, message_type, response)
+      if message_type == MESSAGE_TYPE_EOF
+        eof_thread do
+          @eof_callbacks.each { |block| block.call(msg_id) }
+        end
+      else
+        response_thread do
+          @success_callbacks.each { |block| block.call(msg_id, response) }
+        end
+      end
+    end
+
+    # Handles error responses in Threads
+    # EOF processing waits until all threads are finished
+    def response_error(msg_id, response_code, response)
+      response_thread do
+        @error_callbacks.each { |block| block.call(msg_id, response_code, response) }
+      end
+    end
+
+    # Error state: Any response wasn't received in `Configuration.response_timeout`
+    def response_timeout(msg_id)
+      response_thread do
+        @timeout_callbacks.each { |block| block.call(msg_id) }
+      end
+    end
+
+    private
+
+    # Responses are processed in threads to be able to call subrequests
+    # EOF response is blocked by thread-safe counter
+    def response_thread
+      @responses_count.increment
+
+      Thread.new do
+        yield
+      ensure
+        @responses_count.decrement
+        @eof_lock.synchronize do
+          @eof_wait.signal if @responses_count.value == 0
+        end
+      end
+    end
+
+    # Messages in kafka are received serialized, EOF is always last
+    # => @responses_count has to be always positive
+    #    until all responses are processed
+    def eof_thread
+      Thread.new do
+        @eof_lock.synchronize do
+          @eof_wait.wait(@eof_lock) if @responses_count.value > 0
+        end
+
+        yield
+      end
+    end
+  end
+end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -51,14 +51,14 @@ module ReceptorController
 
         msg_id
       else
-        logger.error(receptor_log_msg("Directive #{name} failed: HTTP #{response.status}", account, node_id))
+        logger.error(receptor_log_msg("Directive #{name} failed (#{log_message_common}): HTTP #{response.status}", account, node_id))
         nil
       end
     rescue Faraday::Error => e
-      logger.error(receptor_log_msg("Directive #{name} failed. POST /job error", account, node_id, e))
+      logger.error(receptor_log_msg("Directive #{name} failed (#{log_message_common}). POST /job error", account, node_id, e))
       nil
     rescue => e
-      logger.error(receptor_log_msg("Directive #{name} failed", account, node_id, e))
+      logger.error(receptor_log_msg("Directive #{name} failed (#{log_message_common})", account, node_id, e))
       nil
     end
 

--- a/lib/receptor_controller/client/exception.rb
+++ b/lib/receptor_controller/client/exception.rb
@@ -1,0 +1,10 @@
+module ReceptorController
+  class Client
+    class Error < StandardError; end
+
+    class ControllerResponseError < Error; end
+    class ResponseTimeoutError < Error; end
+    class ResponseError < Error; end
+    class UnknownResponseTypeError < Error; end
+  end
+end

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -16,7 +16,8 @@ module ReceptorController
   # Use "start" and "stop" methods to start/stop listening on Kafka
   class Client::ResponseWorker
     attr_reader :started
-    alias_method :started?, :started
+    alias started? started
+
 
     attr_accessor :received_messages
 
@@ -93,7 +94,7 @@ module ReceptorController
       response = JSON.parse(message.payload)
 
       if (message_id = response['in_response_to'])
-        logger.debug"------- Receptor response: Received: #{message_id}"
+        logger.debug("Receptor response: Received message_id: #{message_id}")
         if (callbacks = registered_messages[message_id]).present?
           # Reset last_checked_at to avoid timeout in multi-response messages
           reset_last_checked_at(callbacks)
@@ -161,7 +162,6 @@ module ReceptorController
         callbacks[:last_checked_at] = Time.now.utc
       end
     end
-
 
     # No persist_ref here, because all instances (pods) needs to receive kafka message
     def queue_opts

--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -1,15 +1,32 @@
 require "concurrent"
 
 module ReceptorController
+  # ResponseWorker is listening on Kafka topic platform.receptor-controller.responses (@see Configuration.queue_topic)
+  # It asynchronously receives responses requested by POST /job to receptor controller.
+  # Request and response is paired by message ID (response of POST /job and 'in_response_to' value in kafka response here)
+  #
+  # Successful responses are at least two:
+  # * 1+ of 'response' type, containing data
+  # * 1 of 'eof' type, signalizing end of transmission
+  #
+  # Registered messages without response are removed after timeout (Configuration.response_timeout)
+  #
+  # All type of responses/timeout can be sent to registered callbacks (@see :register_message)
+  #
+  # Use "start" and "stop" methods to start/stop listening on Kafka
   class Client::ResponseWorker
     attr_reader :started
     alias_method :started?, :started
 
+    attr_accessor :received_messages
+
     def initialize(config, logger)
       self.config              = config
       self.lock                = Mutex.new
+      self.timeout_lock        = Mutex.new
       self.logger              = logger
       self.registered_messages = Concurrent::Map.new
+      self.received_messages   = Concurrent::Array.new
       self.started             = Concurrent::AtomicBoolean.new(false)
       self.workers             = {}
     end
@@ -20,8 +37,8 @@ module ReceptorController
         return if started.value
 
         started.value         = true
-        workers[:maintenance] = Thread.new { check_timeouts }
-        workers[:listener]    = Thread.new { listen }
+        workers[:maintenance] = Thread.new { check_timeouts while started.value }
+        workers[:listener]    = Thread.new { listen while started.value }
       end
     end
 
@@ -43,13 +60,19 @@ module ReceptorController
     # @param receiver [Object] any object implementing callbacks
     # @param response_callback [Symbol] name of receiver's method processing responses
     # @param timeout_callback [Symbol] name of receiver's method processing timeout [optional]
-    def register_message(msg_id, receiver, response_callback: :response_received, timeout_callback: :response_timeout)
-      registered_messages[msg_id] = {:receiver => receiver, :response_callback => response_callback, :timeout_callback => timeout_callback, :registered_at => Time.now.utc}
+    # @param error_callback [Symbol] name of receiver's method processing errors [optional]
+    def register_message(msg_id, receiver, response_callback: :response_success, timeout_callback: :response_timeout, error_callback: :response_error)
+      logger.debug("Receptor response: registering message #{msg_id}")
+      registered_messages[msg_id] = {:receiver          => receiver,
+                                     :response_callback => response_callback,
+                                     :timeout_callback  => timeout_callback,
+                                     :error_callback    => error_callback,
+                                     :last_checked_at   => Time.now.utc}
     end
 
     private
 
-    attr_accessor :config, :lock, :logger, :registered_messages, :workers
+    attr_accessor :config, :lock, :logger, :registered_messages, :timeout_lock, :workers
     attr_writer :started
 
     def listen
@@ -60,66 +83,91 @@ module ReceptorController
       client.subscribe_topic(queue_opts) do |message|
         process_message(message)
       end
+    rescue => err
+      logger.error("Exception in kafka listener: #{err}\n#{err.backtrace.join("\n")}")
     ensure
       client&.close
     end
 
     def process_message(message)
       response = JSON.parse(message.payload)
-      if response['code'] == 0
-        message_id = response['in_response_to']
-        # message_type: "response" (with data) or
-        #               "eof"(without data)
-        message_type = response['message_type']
 
-        if message_id
-          if (callbacks = registered_messages[message_id]).present?
+      if (message_id = response['in_response_to'])
+        logger.debug"------- Receptor response: Received: #{message_id}"
+        if (callbacks = registered_messages[message_id]).present?
+          # Reset last_checked_at to avoid timeout in multi-response messages
+          reset_last_checked_at(callbacks)
+
+          logger.debug("Receptor response: processing message #{message_id} (#{response})")
+          if response['code'] == 0
+            #
+            # Response OK
+            #
+            message_type = response['message_type'] # "response" (with data) or "eof" (without data)
             registered_messages.delete(message_id) if message_type == 'eof'
-            # Callback to sender
             callbacks[:receiver].send(callbacks[:response_callback], message_id, message_type, response['payload'])
+          else
+            #
+            # Response Error
+            #
+            registered_messages.delete(message_id)
+            callbacks[:receiver].send(callbacks[:error_callback], message_id, response['code'], response['payload'])
           end
         else
-          raise "Message id (in_response_to) not received! #{response}"
+          # noop, it's not error if not registered, can be processed by another pod
         end
       else
-        logger.error("Receptor_satellite:health_check directive failed in receptor_client node #{response['sender']}")
+        logger.error("Receptor response: Message id (in_response_to) not received! #{response}")
       end
     rescue JSON::ParserError => e
-      logger.error("Failed to parse Kafka response (#{e.message})\n#{message.payload}")
+      logger.error("Receptor response: Failed to parse Kafka response (#{e.message})\n#{message.payload}")
     rescue => e
-      logger.error("#{e}\n#{e.backtrace.join("\n")}")
+      logger.error("Receptor response: #{e}\n#{e.backtrace.join("\n")}")
+    ensure
+      message.ack unless config.queue_auto_ack
     end
 
     def check_timeouts(threshold = config.response_timeout)
-      while started.value
-        expired = []
-        #
-        # STEP 1 Collect expired messages
-        #
-        registered_messages.each_pair do |message_id, callbacks|
-          if callbacks[:registered_at] < Time.now.utc - threshold
+      expired = []
+      #
+      # STEP 1 Collect expired messages
+      #
+      registered_messages.each_pair do |message_id, callbacks|
+        timeout_lock.synchronize do
+          if callbacks[:last_checked_at] < Time.now.utc - threshold
             expired << message_id
           end
         end
+      end
 
-        #
-        # STEP 2 Remove expired messages, send timeout callbacks
-        #
-        expired.each do |message_id|
-          callbacks = registered_messages.delete(message_id)
-          if callbacks[:receiver].respond_to?(callbacks[:timeout_callback])
-            callbacks[:receiver].send(callbacks[:timeout_callback], message_id)
-          end
+      #
+      # STEP 2 Remove expired messages, send timeout callbacks
+      #
+      expired.each do |message_id|
+        callbacks = registered_messages.delete(message_id)
+        if callbacks[:receiver].respond_to?(callbacks[:timeout_callback])
+          callbacks[:receiver].send(callbacks[:timeout_callback], message_id)
         end
+      end
 
-        sleep(config.response_timeout_poll_time)
+      sleep(config.response_timeout_poll_time)
+    rescue => err
+      logger.error("Exception in maintenance worker: #{err}\n#{err.backtrace.join("\n")}")
+    end
+
+    # Reset last_checked_at to avoid timeout in multi-response messages
+    def reset_last_checked_at(callbacks)
+      timeout_lock.synchronize do
+        callbacks[:last_checked_at] = Time.now.utc
       end
     end
 
+
     # No persist_ref here, because all instances (pods) needs to receive kafka message
     def queue_opts
-      opts = {:service => config.queue_topic}
-      opts[:max_bytes] = config.queue_max_bytes if config.queue_max_bytes
+      opts               = {:service  => config.queue_topic,
+                            :auto_ack => config.queue_auto_ack}
+      opts[:max_bytes]   = config.queue_max_bytes if config.queue_max_bytes
       opts[:persist_ref] = config.queue_persist_ref if config.queue_persist_ref
       opts
     end
@@ -129,7 +177,7 @@ module ReceptorController
         :host       => config.queue_host,
         :port       => config.queue_port,
         :protocol   => :Kafka,
-        :client_ref => "tp-inventory-receptor_client-responses-#{Time.now.to_i}", # A reference string to identify the client
+        :client_ref => "receptor_client-responses-#{Time.now.to_i}", # A reference string to identify the client
       }
     end
   end

--- a/lib/receptor_controller/client/version.rb
+++ b/lib/receptor_controller/client/version.rb
@@ -1,5 +1,5 @@
 module ReceptorController
   class Client
-    VERSION = "0.0.1"
+    VERSION = "0.0.1".freeze
   end
 end

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.summary     = "Client for communication with Platform Receptor Controller - Gem"
   s.description = "Client for communication with Platform Receptor Controller"
   s.license     = "Apache-2.0"
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_runtime_dependency 'activesupport', '~> 5.2.4.3'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
@@ -27,10 +27,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'
 
   s.add_development_dependency 'bundler', '~> 2.0'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rubocop', '~>0.69.0'
+  s.add_development_dependency 'rubocop-performance', '~>1.3'
   s.add_development_dependency 'simplecov', '~> 0.17.1'
-  s.add_development_dependency "rake", ">= 12.3.3"
+  s.add_development_dependency 'webmock'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '~> 5.2.4.3'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
-  s.add_runtime_dependency 'faraday'
+  s.add_runtime_dependency 'faraday', '~> 1.0'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
   s.add_runtime_dependency 'manageiq-loggers', '~> 0.4.0', '>= 0.4.2'
   s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
   s.add_runtime_dependency 'faraday', '~> 1.0'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
-  s.add_runtime_dependency 'manageiq-loggers', '~> 0.4.0', '>= 0.4.2'
+  s.add_runtime_dependency 'manageiq-loggers', '~> 0.5.0'
   s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'
 
   s.add_development_dependency 'bundler', '~> 2.0'

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '~> 5.2.4.3'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
-  s.add_runtime_dependency 'faraday', '~> 1.0'
+  s.add_runtime_dependency 'faraday'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
   s.add_runtime_dependency 'manageiq-loggers', '~> 0.4.0', '>= 0.4.2'
   s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'

--- a/spec/receptor_controller/client_spec.rb
+++ b/spec/receptor_controller/client_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ReceptorController::Client do
   end
   let(:headers) do
     {"Content-Type"    => "application/json",
-     "User-Agent"      => "Faraday v1.0.1",
      "Accept"          => "*/*",
      "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
   end

--- a/spec/receptor_controller/directive_blocking_spec.rb
+++ b/spec/receptor_controller/directive_blocking_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
   end
 
   let(:payload) { {'method' => :get, 'url' => 'tower.example.com', 'headers' => {}, 'ssl' => false}.to_json }
-  let(:directive) { 'receptor_http:execute'}
+  let(:directive) { 'receptor_http:execute' }
 
   subject { described_class.new(:name => directive, :account => external_tenant, :node_id => receptor_node, :payload => payload, :client => receptor_client) }
 
@@ -56,7 +56,7 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
       expect(subject.response_worker).not_to receive(:register_message)
 
-      expect {subject.call}.to raise_error(ReceptorController::Client::ControllerResponseError)
+      expect { subject.call }.to raise_error(ReceptorController::Client::ControllerResponseError)
     end
 
     context "waiting for callbacks" do
@@ -75,7 +75,6 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
         allow(ManageIQ::Messaging::Client).to receive(:open).and_return(kafka_client)
         allow(kafka_client).to receive(:subscribe_topic).and_yield(kafka_response)
         allow(kafka_client).to receive(:close)
-
       end
 
       it "waits for successful response and sets data" do
@@ -86,11 +85,11 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
         allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
 
-        expect(subject).to receive(:response_success)
+        expect(subject).to(receive(:response_success)
                              .with(response_message['in_response_to'],
                                    response_message['message_type'],
                                    response_message['payload'])
-                             .and_wrap_original do |m, *args|
+                             .and_wrap_original) do |m, *args|
           m.call(*args) # Doesn't release lock, only EOF response can
           subject.send(:response_waiting).signal
           subject.response_worker.stop
@@ -111,11 +110,11 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
         allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
 
-        expect(subject).to receive(:response_success)
+        expect(subject).to(receive(:response_success)
                              .with(response_message['in_response_to'],
                                    response_message['message_type'],
                                    response_message['payload'])
-                             .and_wrap_original do |m, *args|
+                             .and_wrap_original) do |m, *args|
           m.call(*args) # original call releases lock
           subject.response_worker.stop
         end
@@ -135,11 +134,11 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
         allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
 
-        expect(subject).to receive(:response_success)
+        expect(subject).to(receive(:response_success)
                              .with(response_message['in_response_to'],
                                    response_message['message_type'],
                                    response_message['payload'])
-                             .and_wrap_original do |m, *args|
+                             .and_wrap_original) do |m, *args|
           m.call(*args) # original call releases lock
           subject.response_worker.stop
         end
@@ -158,11 +157,11 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
         allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
 
-        expect(subject).to receive(:response_error)
+        expect(subject).to(receive(:response_error)
                              .with(response_message['in_response_to'],
                                    response_message['code'],
                                    response_message['payload'])
-                             .and_wrap_original do |m, *args|
+                             .and_wrap_original) do |m, *args|
           m.call(*args) # original calls releases lock
           subject.response_worker.stop
         end
@@ -180,9 +179,9 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
         allow(kafka_client).to receive(:subscribe_topic).and_return(nil)
 
-        expect(subject).to receive(:response_timeout)
+        expect(subject).to(receive(:response_timeout)
                              .with(http_response['id'])
-                             .and_wrap_original do |m, *args|
+                             .and_wrap_original) do |m, *args|
           m.call(*args) # original call releases lock
           subject.response_worker.stop
         end

--- a/spec/receptor_controller/directive_blocking_spec.rb
+++ b/spec/receptor_controller/directive_blocking_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
   end
   let(:headers) do
     {"Content-Type"    => "application/json",
-     "User-Agent"      => "Faraday v1.0.0",
      "Accept"          => "*/*",
      "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
   end

--- a/spec/receptor_controller/directive_blocking_spec.rb
+++ b/spec/receptor_controller/directive_blocking_spec.rb
@@ -1,0 +1,199 @@
+require "receptor_controller/client/directive_blocking"
+
+RSpec.describe ReceptorController::Client::DirectiveBlocking do
+  # TODO: definitions below contain the same like non-blocking spec
+  let(:external_tenant) { '0000001' }
+  let(:organization_id) { '000001' }
+  let(:identity) do
+    {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => external_tenant, "user" => {"is_org_admin" => true}, "internal" => {"org_id" => organization_id}}}.to_json)}
+  end
+  let(:headers) do
+    {"Content-Type"    => "application/json",
+     "User-Agent"      => "Faraday v1.0.0",
+     "Accept"          => "*/*",
+     "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
+  end
+  let(:receptor_scheme) { 'http' }
+  let(:receptor_host) { 'localhost:9090' }
+  let(:receptor_node) { 'testing-receptor' }
+  let(:receptor_config) do
+    ReceptorController::Client::Configuration.new do |config|
+      config.controller_scheme = receptor_scheme
+      config.controller_host   = receptor_host
+    end
+  end
+  let(:receptor_client) do
+    client = ReceptorController::Client.new(:config => receptor_config)
+    client.identity_header = identity
+    client
+  end
+
+  let(:payload) { {'method' => :get, 'url' => 'tower.example.com', 'headers' => {}, 'ssl' => false}.to_json }
+  let(:directive) { 'receptor_http:execute'}
+
+  subject { described_class.new(:name => directive, :account => external_tenant, :node_id => receptor_node, :payload => payload, :client => receptor_client) }
+
+  describe "#call" do
+    it "makes POST /job request to receptor and registers received message ID" do
+      allow(subject).to receive(:wait_for_response)
+
+      response = {"id" => '1234'}
+
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 200, :body => response.to_json, :headers => {})
+
+      expect(subject.response_worker).to receive(:register_message).with(response['id'], subject)
+
+      subject.call
+    end
+
+    it "raises ControllerResponseError if POST /job returns error" do
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 401, :body => {"errors" => [{"status" => 401, "detail" => "Unauthorized"}]}.to_json, :headers => {})
+
+      expect(subject.response_worker).not_to receive(:register_message)
+
+      expect {subject.call}.to raise_error(ReceptorController::Client::ControllerResponseError)
+    end
+
+    context "waiting for callbacks" do
+      let(:http_response) { {"id" => '1234'} }
+      let(:kafka_client) { double("Kafka client") }
+      let(:kafka_response) { double("Kafka response") }
+
+      before do
+        stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+          .with(:body    => subject.default_body.to_json,
+                :headers => headers)
+          .to_return(:status => 200, :body => http_response.to_json, :headers => {})
+
+        allow(kafka_response).to receive(:ack)
+
+        allow(ManageIQ::Messaging::Client).to receive(:open).and_return(kafka_client)
+        allow(kafka_client).to receive(:subscribe_topic).and_yield(kafka_response)
+        allow(kafka_client).to receive(:close)
+
+      end
+
+      it "waits for successful response and sets data" do
+        response_message = {'code'           => 0,
+                            'in_response_to' => http_response['id'],
+                            'message_type'   => subject.class::MESSAGE_TYPE_RESPONSE,
+                            'payload'        => 'Test payload'}
+
+        allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
+
+        expect(subject).to receive(:response_success)
+                             .with(response_message['in_response_to'],
+                                   response_message['message_type'],
+                                   response_message['payload'])
+                             .and_wrap_original do |m, *args|
+          m.call(*args) # Doesn't release lock, only EOF response can
+          subject.send(:response_waiting).signal
+          subject.response_worker.stop
+        end
+
+        subject.response_worker.start
+        subject.call
+
+        expect(subject.send(:response_data)).to eq(response_message['payload'])
+        expect(subject.send(:response_exception)).to be_nil
+      end
+
+      it "waits for EOF response" do
+        response_message = {'code'           => 0,
+                            'in_response_to' => http_response['id'],
+                            'message_type'   => subject.class::MESSAGE_TYPE_EOF,
+                            'payload'        => 'Unimportant'}
+
+        allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
+
+        expect(subject).to receive(:response_success)
+                             .with(response_message['in_response_to'],
+                                   response_message['message_type'],
+                                   response_message['payload'])
+                             .and_wrap_original do |m, *args|
+          m.call(*args) # original call releases lock
+          subject.response_worker.stop
+        end
+
+        subject.response_worker.start
+        subject.call
+
+        expect(subject.send(:response_data)).to be_nil
+        expect(subject.send(:response_exception)).to be_nil
+      end
+
+      it "raises UnknownResponseTypeError if unknown successful response received" do
+        response_message = {'code'           => 0,
+                            'in_response_to' => http_response['id'],
+                            'message_type'   => 'unknown',
+                            'payload'        => 'Unimportant'}
+
+        allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
+
+        expect(subject).to receive(:response_success)
+                             .with(response_message['in_response_to'],
+                                   response_message['message_type'],
+                                   response_message['payload'])
+                             .and_wrap_original do |m, *args|
+          m.call(*args) # original call releases lock
+          subject.response_worker.stop
+        end
+
+        subject.response_worker.start
+        expect { subject.call }.to raise_error(ReceptorController::Client::UnknownResponseTypeError)
+
+        expect(subject.send(:response_data)).to be_nil
+        expect(subject.send(:response_exception)).to be_kind_of(ReceptorController::Client::UnknownResponseTypeError)
+      end
+
+      it "raises ResponseError if error response received" do
+        response_message = {'code'           => 1,
+                            'in_response_to' => http_response['id'],
+                            'payload'        => 'Some error message'}
+
+        allow(kafka_response).to receive(:payload).and_return(response_message.to_json)
+
+        expect(subject).to receive(:response_error)
+                             .with(response_message['in_response_to'],
+                                   response_message['code'],
+                                   response_message['payload'])
+                             .and_wrap_original do |m, *args|
+          m.call(*args) # original calls releases lock
+          subject.response_worker.stop
+        end
+
+        subject.response_worker.start
+        expect { subject.call }.to raise_error(ReceptorController::Client::ResponseError)
+
+        expect(subject.send(:response_data)).to be_nil
+        expect(subject.send(:response_exception)).to be_kind_of(ReceptorController::Client::ResponseError)
+      end
+
+      it "raises ResponseTimeoutError if timeout response received" do
+        receptor_client.config.response_timeout = 1.second
+        receptor_client.config.response_timeout_poll_time = 0
+
+        allow(kafka_client).to receive(:subscribe_topic).and_return(nil)
+
+        expect(subject).to receive(:response_timeout)
+                             .with(http_response['id'])
+                             .and_wrap_original do |m, *args|
+          m.call(*args) # original call releases lock
+          subject.response_worker.stop
+        end
+
+        subject.response_worker.start
+        expect { subject.call }.to raise_error(ReceptorController::Client::ResponseTimeoutError)
+
+        expect(subject.send(:response_data)).to be_nil
+        expect(subject.send(:response_exception)).to be_kind_of(ReceptorController::Client::ResponseTimeoutError)
+      end
+    end
+  end
+end

--- a/spec/receptor_controller/directive_non_blocking_spec.rb
+++ b/spec/receptor_controller/directive_non_blocking_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
   end
   let(:headers) do
     {"Content-Type"    => "application/json",
-     "User-Agent"      => "Faraday v1.0.0",
      "Accept"          => "*/*",
      "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
   end

--- a/spec/receptor_controller/directive_non_blocking_spec.rb
+++ b/spec/receptor_controller/directive_non_blocking_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
     client
   end
 
-
   let(:satellite_uid) { '1234567890' }
   let(:payload) { {'satellite_instance_id' => satellite_uid.to_s}.to_json }
   let(:directive) { 'receptor_satellite:health_check' }

--- a/spec/receptor_controller/directive_non_blocking_spec.rb
+++ b/spec/receptor_controller/directive_non_blocking_spec.rb
@@ -1,0 +1,162 @@
+require "receptor_controller/client/directive_non_blocking"
+
+RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
+  let(:external_tenant) { '0000001' }
+  let(:organization_id) { '000001' }
+  let(:identity) do
+    {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => external_tenant, "user" => {"is_org_admin" => true}, "internal" => {"org_id" => organization_id}}}.to_json)}
+  end
+  let(:headers) do
+    {"Content-Type"    => "application/json",
+     "User-Agent"      => "Faraday v1.0.0",
+     "Accept"          => "*/*",
+     "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
+  end
+  let(:receptor_scheme) { 'http' }
+  let(:receptor_host) { 'localhost:9090' }
+  let(:receptor_node) { 'testing-receptor' }
+  let(:receptor_config) do
+    ReceptorController::Client::Configuration.new do |config|
+      config.controller_scheme = receptor_scheme
+      config.controller_host   = receptor_host
+    end
+  end
+  let(:receptor_client) do
+    client = ReceptorController::Client.new
+    client.identity_header = identity
+    client
+  end
+
+
+  let(:satellite_uid) { '1234567890' }
+  let(:payload) { {'satellite_instance_id' => satellite_uid.to_s}.to_json }
+  let(:directive) { 'receptor_satellite:health_check' }
+
+  subject { described_class.new(:name => directive, :account => external_tenant, :node_id => receptor_node, :payload => payload, :client => receptor_client) }
+
+  describe "#call" do
+    it "makes POST /job request to receptor, registers received message ID and returns it" do
+      response = {"id" => '1234'}
+
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 200, :body => response.to_json, :headers => {})
+
+      expect(subject.response_worker).to receive(:register_message).with(response['id'], subject)
+
+      expect(subject.call).to eq(response['id'])
+    end
+
+    it "makes POST /job request to receptor, doesn't register message and returns nil in case of error" do
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 401, :body => {"errors" => [{"status" => 401, "detail" => "Unauthorized"}]}.to_json, :headers => {})
+
+      expect(subject.response_worker).not_to receive(:register_message)
+
+      expect(subject.call).to be_nil
+    end
+
+    it "makes a POST request and returns disconnected if receptor unavailable" do
+      allow(Faraday).to receive(:post).and_raise(Faraday::ConnectionFailed, "Failed to open TCP connection to #{receptor_host}")
+
+      expect(subject.response_worker).not_to receive(:register_message)
+
+      expect(subject.call).to be_nil
+    end
+  end
+
+  context "callbacks" do
+    let(:response_id) { '1234' }
+    let(:response) { double('Kafka response', :ack => nil) }
+
+    before do
+      # HTTP request
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers)
+        .to_return(:status => 200, :body => {'id' => response_id}.to_json, :headers => {})
+
+      subject.call
+    end
+
+    it "calls success/eof blocks" do
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+
+      # Callbacks
+      result = {}
+      subject
+        .on_success do |msg_id, payload|
+          result[:first] = {:id => msg_id, :payload => payload}
+        end
+        .on_success do |msg_id, payload|
+          result[:second] = {:id => msg_id, :payload => payload}
+        end
+        .on_eof do |msg_id|
+          result[:eof] = {:id => msg_id}
+          mutex.synchronize { cv.signal }
+        end
+
+      # Kafka response - 'response' type
+      expect(subject).to receive(:response_success).twice.and_call_original
+      message_type, payload = 'response', 'Testing payload'
+      response_payload = {'code' => 0, 'in_response_to' => response_id, 'message_type' => message_type, 'payload' => payload}
+      allow(response).to receive(:payload).and_return(response_payload.to_json)
+      subject.response_worker.send(:process_message, response)
+
+      # Kafka response - 'eof' type
+      message_type = 'eof'
+      response_payload = {'code' => 0, 'in_response_to' => response_id, 'message_type' => message_type, 'payload' => nil}
+      allow(response).to receive(:payload).and_return(response_payload.to_json)
+      subject.response_worker.send(:process_message, response)
+
+      mutex.synchronize { cv.wait(mutex) }
+
+      # Result containing both "on_success" blocks
+      block_result = {:id => response_id, :payload => payload}
+      expect(result).to eq(:first  => block_result,
+                           :second => block_result,
+                           :eof    => {:id => response_id})
+    end
+
+    it "processes eof blocks always after all success blocks" do
+      success_cnt = Concurrent::AtomicFixnum.new(0)
+
+      success_calls = 3
+
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+
+      # Callbacks
+      subject
+        .on_success do |_msg_id, _payload|
+          success_cnt.increment
+        end
+        .on_eof do |_msg_id|
+          # Tests
+          expect(success_cnt.value).to eq(success_calls)
+
+          mutex.synchronize { cv.signal }
+        end
+
+      # Kafka response - 'response' type - success
+      message_type, payload = 'response', 'Testing payload'
+      response_payload = {'code' => 0, 'in_response_to' => response_id, 'message_type' => message_type, 'payload' => payload}
+      allow(response).to receive(:payload).and_return(response_payload.to_json)
+      success_calls.times do
+        subject.response_worker.send(:process_message, response)
+      end
+
+      # Kafka response - 'eof' type
+      message_type = 'eof'
+      response_payload = {'code' => 0, 'in_response_to' => response_id, 'message_type' => message_type, 'payload' => nil}
+      allow(response).to receive(:payload).and_return(response_payload.to_json)
+      subject.response_worker.send(:process_message, response)
+
+      mutex.synchronize { cv.wait(mutex) }
+    end
+  end
+end

--- a/spec/receptor_controller/response_worker_spec.rb
+++ b/spec/receptor_controller/response_worker_spec.rb
@@ -1,0 +1,152 @@
+require "receptor_controller/client/response_worker"
+
+RSpec.describe ReceptorController::Client::ResponseWorker do
+  let(:receiver) { double('receiver') }
+  let(:logger) { double('logger') }
+  let(:config) { double('config') }
+
+  subject { described_class.new(config, logger) }
+
+  before do
+    allow(logger).to receive_messages(%i[debug info warn error fatal])
+    allow(config).to receive_messages(:queue_auto_ack => false, :response_timeout => 0, :response_timeout_poll_time => 0)
+  end
+
+  describe "#register_message" do
+    it "saves callback with message id" do
+      msg_id = '1'
+
+      subject.register_message(msg_id, receiver)
+
+      expect(subject.send(:registered_messages)[msg_id]).to match(hash_including(:receiver => receiver))
+    end
+  end
+
+  describe "#process_message" do
+    let(:message) { double('message') }
+    let(:message_id) { '1234' }
+    let(:response_body) { 'Test response' }
+    let(:payload) { {} }
+    let(:receiver) { double('receiver') }
+
+    before do
+      allow(message).to receive(:payload).and_return(payload.to_json)
+
+      allow(receiver).to receive_messages(:success => nil, :timeout => nil, :error => nil)
+
+      subject.register_message(message_id, receiver, :response_callback => :success, :timeout_callback => :timeout, :error_callback => :error)
+    end
+
+    context "with message auto_ack => false" do
+      before do
+        expect(message).to receive(:ack)
+      end
+
+      context "receives successful response" do
+        let(:payload) { {'code' => 0, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
+
+        it "and calls response_callback " do
+          expect(receiver).to receive(:success).with(message_id, payload['message_type'], payload['payload'])
+
+          subject.send(:process_message, message)
+        end
+
+        it "resets last_checked_at timestamp" do
+          callbacks = subject.send(:registered_messages)[message_id]
+          registered_at = callbacks[:last_checked_at]
+
+          subject.send(:process_message, message)
+          expect(callbacks[:last_checked_at] > registered_at)
+        end
+      end
+
+      context "receives error response" do
+        let(:payload) { {'code' => 1, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
+
+        it "and calls response_error" do
+          expect(receiver).to receive(:error).with(message_id, payload['code'], payload['payload'])
+
+          subject.send(:process_message, message)
+        end
+
+        it "resets last_checked_at timestamp" do
+          callbacks = subject.send(:registered_messages)[message_id]
+          registered_at = callbacks[:last_checked_at]
+
+          subject.send(:process_message, message)
+          expect(callbacks[:last_checked_at] > registered_at)
+        end
+      end
+
+      context "receives invalid message" do
+        let(:payload) { 'Wrong message' }
+        before do
+          allow(message).to receive(:payload).and_return(payload)
+        end
+
+        it "logs error" do
+          expect(logger).to receive(:error).with(/Receptor response: Failed to parse Kafka response/)
+
+          subject.send(:process_message, message)
+        end
+      end
+
+      context "receives response without ID" do
+        let(:payload) { {'code' => 0, 'message_type' => 'response', 'payload' => response_body} }
+
+        it "logs error" do
+          expect(logger).to receive(:error).with(/Receptor response: Message id \(in_response_to\) not received!/)
+
+          subject.send(:process_message, message)
+        end
+      end
+
+      context "receives unregistered response" do
+        let(:payload) { {'code' => 0, 'in_response_to' => '9876', 'message_type' => 'response', 'payload' => response_body} }
+
+        it "does nothing" do
+          expect(logger).not_to receive(:error)
+          %i[success error timeout].each do |callback|
+            expect(receiver).not_to receive(callback)
+          end
+
+          subject.send(:process_message, message)
+        end
+      end
+    end
+
+    context "with message auto_ack => true" do
+      before do
+        allow(config).to receive(:queue_auto_ack).and_return(true)
+        expect(message).not_to receive(:ack)
+      end
+
+      let(:payload) { {'code' => 0, 'in_response_to' => message_id, 'message_type' => 'response', 'payload' => response_body} }
+
+      it "doesn't call ack on message" do
+        subject.send(:process_message, message)
+      end
+    end
+  end
+
+  describe "#check_timeouts" do
+    let(:message_id) { '1234' }
+    let(:receiver) { double('receiver') }
+
+    before do
+      allow(receiver).to receive(:timeout) do
+        subject.send(:started).value = false
+      end
+
+      subject.register_message(message_id, receiver, :response_callback => :success, :timeout_callback => :timeout, :error_callback => :error)
+    end
+
+    it "calls timeout callback if message found" do
+      subject.send(:started).value = true
+
+      expect(receiver).to receive(:timeout)
+
+      subject.send(:check_timeouts)
+    end
+  end
+end


### PR DESCRIPTION
**Issue**: #2

Directives (requests through cloud receptor controller) can be blocking (synchronous requests) and non-blocking (asynchronous). 

Description for non-blocking directive is in #4. 

Description for blocking directive:

It sends POST /job request to receptor controller and then waits for signal from response callbacks. 
Callbacks are there part of directive (in opposite to non-blocking directive).
They sets either `response_data` in case of success or `response_exception`.

Lock is released either when `EOF` or error message comes from kafka (not released by `response` message containing data) or by timeout (which also sets `response_exception`)

Response is returned in the same thread as request was called.

