### PR TITLE
Fixing uninitialized constant WebMock::RequestBodyDiff::HashDiff

### DIFF
--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
-  s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
+  s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov', '~> 0.17.1'
-  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "rake", ">= 12.3.3"
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/spec/receptor_controller/client_spec.rb
+++ b/spec/receptor_controller/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReceptorController::Client do
   end
   let(:headers) do
     {"Content-Type"    => "application/json",
-     "User-Agent"      => "Faraday v1.0.0",
+     "User-Agent"      => "Faraday v1.0.1",
      "Accept"          => "*/*",
      "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
   end


### PR DESCRIPTION
Updating the Faraday User-Agent fixes an `uninitialized constant`.

Checking the other repos we do not place a version constraint on the `webmock` gem and removing it here fixes the `undefined method 'close' for #<StubSocket` that I was running into after fixing the User-Agent issue.