### PR TITLE
Support for x-rh-rbac-psk header

### DIFF
--- a/lib/receptor_controller/client.rb
+++ b/lib/receptor_controller/client.rb
@@ -65,7 +65,7 @@ module ReceptorController
     end
 
     def headers
-      default_headers.merge(identity_header || {})
+      default_headers.merge(auth_headers || {})
     end
 
     def receptor_log_msg(msg, account, node_id, exception = nil)
@@ -77,5 +77,14 @@ module ReceptorController
     private
 
     attr_writer :config
+
+    # Use x-rh-rbac-psk if present, x-rh-identity otherwise
+    def auth_headers
+      if config.pre_shared_key.present?
+        {'x-rh-rbac-psk' => config.pre_shared_key}
+      else
+        identity_header || {}
+      end
+    end
   end
 end

--- a/lib/receptor_controller/client/configuration.rb
+++ b/lib/receptor_controller/client/configuration.rb
@@ -10,6 +10,9 @@ module ReceptorController
     # Path to sending directive requests
     attr_accessor :job_path
 
+    # x-rh-rbac-psk header for authentication with receptor controller (replaces x-rh-identity)
+    attr_accessor :pre_shared_key
+
     # Kafka message auto-ack (default false)
     attr_accessor :queue_auto_ack
     # Kafka host name
@@ -34,6 +37,7 @@ module ReceptorController
 
       @connection_status_path = '/connection/status'
       @job_path               = '/job'
+      @pre_shared_key         = nil
 
       @queue_auto_ack    = false
       @queue_host        = nil

--- a/spec/receptor_controller/client_spec.rb
+++ b/spec/receptor_controller/client_spec.rb
@@ -68,4 +68,20 @@ RSpec.describe ReceptorController::Client do
       end
     end
   end
+
+  describe "#headers" do
+    let(:pre_shared_key) { '123456789' }
+
+    it "uses identity_header if PSK is not provided" do
+      expect(subject.headers).to eq({"Content-Type" => "application/json"}.merge(identity))
+    end
+
+    it "uses pre-shared key if provided" do
+      subject.config.configure do |config|
+        config.pre_shared_key = pre_shared_key
+      end
+
+      expect(subject.headers).to eq({"Content-Type" => "application/json", "x-rh-rbac-psk" => pre_shared_key})
+    end
+  end
 end


### PR DESCRIPTION
We can auth to cloud receptor controller by `x-rh-rbac-psk` header at first place. 
If key is not provided, `x-rh-identity` can be used instead