### PR TITLE
Unique persist-ref for every response worker

### DIFF
--- a/lib/receptor_controller/client/configuration.rb
+++ b/lib/receptor_controller/client/configuration.rb
@@ -42,7 +42,7 @@ module ReceptorController
       @queue_auto_ack    = true
       @queue_host        = nil
       @queue_max_bytes   = nil
-      @queue_persist_ref = nil
+      @queue_persist_ref = "receptor-client.#{SecureRandom.uuid}"
       @queue_port        = nil
       @queue_topic       = 'platform.receptor-controller.responses'
 

--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -20,7 +20,7 @@ module ReceptorController
 
       msg_id = JSON.parse(response.body)['id']
 
-      logger.debug("Receptor response: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+      logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
       # registers message id for kafka responses
       response_worker.register_message(msg_id, self)
       wait_for_response(msg_id)

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -48,7 +48,7 @@ module ReceptorController
 
         # registers message id for kafka responses
         response_worker.register_message(msg_id, self)
-        logger.debug("Receptor response: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+        logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
 
         msg_id
       else

--- a/spec/receptor_controller/response_worker_spec.rb
+++ b/spec/receptor_controller/response_worker_spec.rb
@@ -9,7 +9,13 @@ RSpec.describe ReceptorController::Client::ResponseWorker do
 
   before do
     allow(logger).to receive_messages(%i[debug info warn error fatal])
-    allow(config).to receive_messages(:queue_auto_ack => false, :response_timeout => 0, :response_timeout_poll_time => 0)
+    allow(config).to receive_messages(:queue_auto_ack => false,
+                                      :queue_max_bytes => nil,
+                                      :queue_persist_ref => 'consumer-group-1',
+                                      :queue_topic => 'receptor.kafka.topic',
+                                      :response_timeout => 0,
+                                      :response_timeout_poll_time => 0,
+                                      )
   end
 
   describe "#register_message" do
@@ -87,7 +93,7 @@ RSpec.describe ReceptorController::Client::ResponseWorker do
         end
 
         it "logs error" do
-          expect(logger).to receive(:error).with(/Receptor response: Failed to parse Kafka response/)
+          expect(logger).to receive(:error).with(/Failed to parse Kafka response/)
 
           subject.send(:process_message, message)
         end
@@ -97,7 +103,7 @@ RSpec.describe ReceptorController::Client::ResponseWorker do
         let(:payload) { {'code' => 0, 'message_type' => 'response', 'payload' => response_body} }
 
         it "logs error" do
-          expect(logger).to receive(:error).with(/Receptor response: Message id \(in_response_to\) not received!/)
+          expect(logger).to receive(:error).with(/Message id \(in_response_to\) not received!/)
 
           subject.send(:process_message, message)
         end


### PR DESCRIPTION
As we're losing some kafka messages on server, I want to change `persist_ref` from nil to unique value. Maybe it's not reliable to broadcast messages to all consumers without group.