### PR TITLE
Waiting for response-worker kafka init

### DIFF
--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -1,3 +1,4 @@
+require 'active_support/notifications'
 require 'base64'
 require "concurrent"
 require 'stringio'
@@ -39,13 +40,23 @@ module ReceptorController
 
     # Start listening on Kafka
     def start
+      init_lock, init_wait = Mutex.new, ConditionVariable.new
+
       lock.synchronize do
         return if started.value
+
+        default_messaging_opts # Thread-safe init
+        init_notifications(init_lock, init_wait)
 
         started.value         = true
         workers[:maintenance] = Thread.new { check_timeouts while started.value }
         workers[:listener]    = Thread.new { listen while started.value }
       end
+
+      # Wait for kafka initialization
+      wait_for_notifications(init_lock, init_wait)
+
+      logger.info("Receptor Response worker started...")
     end
 
     # Stop listener
@@ -56,6 +67,28 @@ module ReceptorController
         started.value = false
         workers[:listener]&.terminate
         workers[:maintenance]&.join
+      end
+    end
+
+    # Listening for the consumer call to the Fetch API
+    # Then releasing original starting thread
+    def init_notifications(init_lock, init_wait)
+      ActiveSupport::Notifications.subscribe('request.connection.kafka') do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        if default_messaging_opts[:client_ref] == event.payload[:client_id]
+          if event.payload[:api] == :fetch
+            logger.debug "Receptor Response: Kafka event #{event.name} from Fetch API received...#{event.payload.inspect}"
+            # initialized, unsubscribe notifications
+            ActiveSupport::Notifications.unsubscribe('request.connection.kafka')
+            init_lock.synchronize { init_wait.signal }
+          end
+        end
+      end
+    end
+
+    def wait_for_notifications(init_lock, init_wait)
+      init_lock.synchronize do
+        init_wait.wait(init_lock)
       end
     end
 
@@ -84,7 +117,6 @@ module ReceptorController
       # Open a connection to the messaging service
       client = ManageIQ::Messaging::Client.open(default_messaging_opts)
 
-      logger.info("Receptor Response worker started...")
       client.subscribe_topic(queue_opts) do |message|
         process_message(message)
       end
@@ -226,7 +258,9 @@ module ReceptorController
     end
 
     def default_messaging_opts
-      {
+      return @default_messaging_opts if @default_messaging_opts
+
+      @default_messaging_opts = {
         :host       => config.queue_host,
         :port       => config.queue_port,
         :protocol   => :Kafka,

--- a/spec/receptor_controller/directive_blocking_spec.rb
+++ b/spec/receptor_controller/directive_blocking_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe ReceptorController::Client::DirectiveBlocking do
 
   subject { described_class.new(:name => directive, :account => external_tenant, :node_id => receptor_node, :payload => payload, :client => receptor_client) }
 
+  before do
+    allow(subject.response_worker).to receive_messages(:init_notifications => nil, :wait_for_notifications => nil)
+  end
+
   describe "#call" do
     it "makes POST /job request to receptor and registers received message ID" do
       allow(subject).to receive(:wait_for_response)


### PR DESCRIPTION
It seems like first set of response messages are sometimes lost. 

This PR blocks starting thread until kafka listener requests kafka Fetch API.

---

**Dependents**:
- https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/114