### PR TITLE
Fix href_slug in directives log

### DIFF
--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -20,7 +20,7 @@ module ReceptorController
 
       msg_id = JSON.parse(response.body)['id']
 
-      logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+      logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{log_message_common}")
       # registers message id for kafka responses
       response_worker.register_message(msg_id, self)
       wait_for_response(msg_id)

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -48,7 +48,7 @@ module ReceptorController
 
         # registers message id for kafka responses
         response_worker.register_message(msg_id, self)
-        logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+        logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{log_message_common}")
 
         msg_id
       else


### PR DESCRIPTION
Because the `body[:payload]` is JSON, it doesn't log the slug.

Tower is storing href_slug to directive's variable so it's used instead.
These log messages should be temporary so I think this workaround is fine