### PR TITLE
Fixed logging of href_slug

### DIFF
--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -19,8 +19,9 @@ module ReceptorController
       response = connection.post(config.job_path, body.to_json)
 
       msg_id = JSON.parse(response.body)['id']
+      href_slug = JSON.parse(body[:payload])['href_slug']
 
-      logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+      logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{href_slug}")
       # registers message id for kafka responses
       response_worker.register_message(msg_id, self)
       wait_for_response(msg_id)

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -45,10 +45,11 @@ module ReceptorController
       response = Faraday.post(config.job_url, body.to_json, client.headers)
       if response.success?
         msg_id = JSON.parse(response.body)['id']
+        href_slug = JSON.parse(body[:payload])['href_slug']
 
         # registers message id for kafka responses
         response_worker.register_message(msg_id, self)
-        logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{body[:payload]["href_slug"]}")
+        logger.debug("Receptor response [#{ReceptorController::Client::Configuration.default.queue_persist_ref}]: registering message #{msg_id}, href_slug: #{href_slug}")
 
         msg_id
       else


### PR DESCRIPTION
There was a bug in logging the href_slug it used to print the string href_slug

e.g.
```
{"@timestamp":"2020-08-11T18:35:04.689553 ","hostname":"collector-ansible-tower-63262190-1-29j7n","pid":1,"tid":"2adee81b163c","level":"debug","message":"Receptor response [receptor-client.9b680d9b-4d8e-4e58-b232-7583c825aa13]: registering message b2791b2a-c5cf-4d59-826c-ae610135facc, href_slug: href_slug"}
```