### PR TITLE
Update ResponseWorker to use ENV['HOSTNAME'] as persist_ref

### DIFF
--- a/lib/receptor_controller/client/response_worker.rb
+++ b/lib/receptor_controller/client/response_worker.rb
@@ -221,7 +221,7 @@ module ReceptorController
       @queue_opts               = {:service  => config.queue_topic,
                                    :auto_ack => config.queue_auto_ack}
       @queue_opts[:max_bytes]   = config.queue_max_bytes if config.queue_max_bytes
-      @queue_opts[:persist_ref] = config.queue_persist_ref if config.queue_persist_ref
+      @queue_opts[:persist_ref] = ENV['HOSTNAME']
       @queue_opts
     end
 


### PR DESCRIPTION
This should be better than a completely random persist_ref, we have the HOSTNAME set to the name of the pod in k8s, as seen here:
```
[ ⚛ ] crc $ k exec -it tower-collector-dev-5597ccb49-97bd7 -- env | grep HOSTNAME
HOSTNAME=tower-collector-dev-5597ccb49-97bd7
```

