### PR TITLE
Rdkafka changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.7]
+- rdkafka changes #32
+
 ## [0.0.6]
 - Waiting for response-worker kafka init #20
 - Fix href_slug in directives log #29
@@ -27,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added extra logging for messages
 
-[Unreleased]: https://github.com/RedHatInsights/receptor_controller-client-ruby/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/RedHatInsights/receptor_controller-client-ruby/compare/v0.0.7...HEAD
+[0.0.6]: https://github.com/RedHatInsights/receptor_controller-client-ruby/releases/tag/v0.0.7
 [0.0.6]: https://github.com/RedHatInsights/receptor_controller-client-ruby/releases/tag/v0.0.6
 [0.0.5]: https://github.com/RedHatInsights/receptor_controller-client-ruby/releases/tag/v0.0.5
 [0.0.4]: https://github.com/RedHatInsights/receptor_controller-client-ruby/releases/tag/v0.0.4

--- a/lib/receptor_controller/client/version.rb
+++ b/lib/receptor_controller/client/version.rb
@@ -1,5 +1,5 @@
 module ReceptorController
   class Client
-    VERSION = "0.0.6".freeze
+    VERSION = "0.0.7".freeze
   end
 end

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '~> 1.0'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
   s.add_runtime_dependency 'manageiq-loggers', '~> 0.5.0'
-  s.add_runtime_dependency 'manageiq-messaging', '~> 0.1.5'
+  s.add_runtime_dependency 'manageiq-messaging', '~> 1.0.0'
 
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '>= 12.3.3'


### PR DESCRIPTION
Basically just removing the wait-lock at the beginning of the `ResponseWorker#start` method as well as bumping the runtime version dependency on manageiq-messaging. 