### PR TITLE
Fix Directives with PSK header

### DIFF
--- a/lib/receptor_controller/client/directive_blocking.rb
+++ b/lib/receptor_controller/client/directive_blocking.rb
@@ -74,7 +74,7 @@ module ReceptorController
     attr_accessor :response_data, :response_exception, :response_lock, :response_waiting
 
     def connection
-      @connection ||= Faraday.new(config.controller_url, :headers => client.headers) do |c|
+      @connection ||= Faraday.new(config.controller_url, :headers => client.headers(account)) do |c|
         c.use(Faraday::Response::RaiseError)
         c.adapter(Faraday.default_adapter)
       end

--- a/lib/receptor_controller/client/directive_non_blocking.rb
+++ b/lib/receptor_controller/client/directive_non_blocking.rb
@@ -42,7 +42,7 @@ module ReceptorController
 
     # Entrypoint for request
     def call(body = default_body)
-      response = Faraday.post(config.job_url, body.to_json, client.headers)
+      response = Faraday.post(config.job_url, body.to_json, client.headers(account))
       if response.success?
         msg_id = JSON.parse(response.body)['id']
 

--- a/spec/receptor_controller/directive_non_blocking_spec.rb
+++ b/spec/receptor_controller/directive_non_blocking_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
   let(:identity) do
     {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => external_tenant, "user" => {"is_org_admin" => true}, "internal" => {"org_id" => organization_id}}}.to_json)}
   end
-  let(:headers) do
+  let(:pre_shared_key) { '1234' }
+  let(:pre_shared_key_headers) do
+    {
+      'x-rh-receptor-controller-psk'       => pre_shared_key,
+      'x-rh-receptor-controller-client-id' => "topological-inventory",
+      'x-rh-receptor-controller-account'   => external_tenant
+    }
+  end
+  let(:headers_common) do
     {"Content-Type"    => "application/json",
      "Accept"          => "*/*",
-     "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}.merge(identity)
+     "Accept-Encoding" => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}
   end
+  let(:headers) { headers_common.merge(identity) }
+  let(:headers_psk) { headers_common.merge(pre_shared_key_headers) }
   let(:receptor_scheme) { 'http' }
   let(:receptor_host) { 'localhost:9090' }
   let(:receptor_node) { 'testing-receptor' }
@@ -21,7 +31,7 @@ RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
     end
   end
   let(:receptor_client) do
-    client = ReceptorController::Client.new
+    client = ReceptorController::Client.new(:config => receptor_config)
     client.identity_header = identity
     client
   end
@@ -63,6 +73,19 @@ RSpec.describe ReceptorController::Client::DirectiveNonBlocking do
       expect(subject.response_worker).not_to receive(:register_message)
 
       expect(subject.call).to be_nil
+    end
+
+    it "makes a POST request with PSK headers if provided" do
+      receptor_config.pre_shared_key = pre_shared_key
+
+      response = {"id" => '1234'}
+
+      stub_request(:post, "#{receptor_scheme}://#{receptor_host}/job")
+        .with(:body    => subject.default_body.to_json,
+              :headers => headers_psk)
+        .to_return(:status => 200, :body => response.to_json, :headers => {})
+
+      expect(subject.call).to eq(response['id'])
     end
   end
 


### PR DESCRIPTION
It seems the problem with not working Satellite PSK headers is not in the Satellite repo, but they were never used in the Ansible Tower collector/operations so it was the first occurence in the Satellite, because `/connection/status` endpoint doesn't use directives

So probably the psk is not properly configured on stage and prod (CI works fine).

This PR fixes directives so they will use the PSK header, if provided

---

[RHCLOUD-11735](https://issues.redhat.com/browse/RHCLOUD-11735)