### PR TITLE
Configurable Receptor Client ID header

### DIFF
--- a/lib/receptor_controller/client.rb
+++ b/lib/receptor_controller/client.rb
@@ -83,7 +83,7 @@ module ReceptorController
       if config.pre_shared_key.present? && account.present?
         {
           'x-rh-receptor-controller-psk'       => config.pre_shared_key,
-          'x-rh-receptor-controller-client-id' => "topological-inventory",
+          'x-rh-receptor-controller-client-id' => config.client_id_header,
           'x-rh-receptor-controller-account'   => account
         }
       else

--- a/lib/receptor_controller/client/configuration.rb
+++ b/lib/receptor_controller/client/configuration.rb
@@ -1,5 +1,8 @@
 module ReceptorController
   class Client::Configuration
+
+    # x-rh-receptor-controller-client-id header for authentication with receptor controller (replaces x-rh-identity)
+    attr_reader :client_id_header
     # Scheme of cloud receptor controller
     attr_reader :controller_scheme
     # Host name of cloud receptor controller
@@ -10,7 +13,7 @@ module ReceptorController
     # Path to sending directive requests
     attr_accessor :job_path
 
-    # x-rh-rbac-psk header for authentication with receptor controller (replaces x-rh-identity)
+    # x-rh-receptor-controller-psk header for authentication with receptor controller (replaces x-rh-identity)
     attr_accessor :pre_shared_key
 
     # Kafka message auto-ack (default false)
@@ -38,6 +41,7 @@ module ReceptorController
       @connection_status_path = '/connection/status'
       @job_path               = '/job'
       @pre_shared_key         = nil
+      @client_id_header       = 'topological-inventory'
 
       @queue_auto_ack    = true
       @queue_host        = nil

--- a/receptor_controller-client.gemspec
+++ b/receptor_controller-client.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
   s.license     = "Apache-2.0"
   s.required_ruby_version = ">= 2.5"
 
-  s.add_runtime_dependency 'activesupport', '~> 5.2.4.3'
+  s.add_runtime_dependency 'activesupport', '~> 5.2'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1', '>= 1.1.6'
   s.add_runtime_dependency 'faraday', '~> 1.0'
   s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.0'
-  s.add_runtime_dependency 'manageiq-loggers', '~> 0.5.0'
+  s.add_runtime_dependency 'manageiq-loggers', '~> 0.5'
   s.add_runtime_dependency 'manageiq-messaging', '~> 1.0.0'
 
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
The client ID was hardcoded, should be configurable to support sources-satellite

---
[RHCLOUD-13529](https://issues.redhat.com/browse/RHCLOUD-13529)